### PR TITLE
Use assert.equal to improve test failure message

### DIFF
--- a/test.js
+++ b/test.js
@@ -13,6 +13,6 @@ var prefix = require('./');
 
 describe('prefix', function() {
   it('should:', function() {
-    assert(prefix == '/usr/local');
+    assert.equal('/usr/local', prefix);
   });
 });


### PR DESCRIPTION
The current error message is `AssertionError: false == true`. With this change, it will be more meaningful, showing the actual and expected string values.
