### PR TITLE
Traverse all npm config (npmrc) files to find global prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "is-windows": "^0.1.1"
+    "ini": "^1.3.4",
+    "is-windows": "^0.1.1",
+    "osenv": "^0.1.3",
+    "which": "^1.2.9"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.7",


### PR DESCRIPTION
Hi, I made some changes to fix #3, it is not pretty though! 😄

It is a very big change, but should reflect how npm currently gets the global prefix. I kept the code synchronous, but an asynchronous version would probably be better for this.

I don't think there is a way around all the IO. In my case i installed node using homebrew and the module would give me the global prefix as `/usr/local/Cellar/node/6.2.0` because of `process.execPath`, but it was by default being set to `/usr/local` in the builtin [npmrc](https://docs.npmjs.com/files/npmrc).
