### PR TITLE
Path fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
-  - "stable"
+  - "6"
   - "5"
   - "4"
   - "0.12"
   - "0.10"
-matrix:
-  fast_finish: true
-  allow_failures:
-    - node_js: "0.10"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "6.0"
+    - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@
 
 'use strict';
 
-var fs = require('fs')
+var homedir = require('homedir-polyfill');
 var path = require('path');
-var osenv = require('osenv');
 var ini = require('ini');
+var fs = require('fs')
 
 var prefix;
 
@@ -18,7 +18,7 @@ if (process.env.PREFIX) {
   prefix = process.env.PREFIX;
 } else {
   // Start by checking if the global prefix is set by the user
-  var userConfig = path.resolve(osenv.home(), '.npmrc');
+  var userConfig = path.resolve(homedir(), '.npmrc');
   prefix = readPrefix(userConfig);
 
   if (!prefix) {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "test": "mocha"
   },
   "dependencies": {
+    "homedir-polyfill": "^1.0.0",
     "ini": "^1.3.4",
     "is-windows": "^0.2.0",
-    "osenv": "^0.1.3",
     "which": "^1.2.10"
   },
   "devDependencies": {
+    "fs-exists-sync": "^0.1.0",
     "gulp-format-md": "^0.1.9",
     "mocha": "^2.5.3"
   },

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ require('mocha');
 var path = require('path');
 var assert = require('assert');
 var isWindows = require('is-windows');
+var exists = require('fs-exists-sync');
 var prefix = require('./');
 
 describe('prefix', function() {
@@ -18,13 +19,9 @@ describe('prefix', function() {
     it('should resolve the path to the windows global prefix:', function() {
       assert.equal(path.dirname(process.execPath), prefix);
     });
-  } else {
-    it('should resolve the path to the global prefix:', function() {
-      if (process.env.DESTDIR) {
-        assert.equal(path.join(process.env.DESTDIR, '/usr/local'), prefix);
-      } else {
-        assert.equal('/usr/local', prefix);
-      }
-    });
   }
+
+  it('should resolve the path to the global prefix:', function() {
+    assert(exists(prefix));
+  });
 });


### PR DESCRIPTION
This PR should address the currently open issues #11, #12 and fix the problem for the PR #10.

This is done by replacing `osenv` with `homedir-polyfill` and updating the tests to check that the returned prefix path exists.
