### PR TITLE
Bump version kind-of to 6.0.3 to fix CVE-2019-20149

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "ini": "^1.3.5",
-    "kind-of": "^6.0.2",
+    "kind-of": "^6.0.3",
     "which": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Due to [CVE-2019-20149](https://nvd.nist.gov/vuln/detail/CVE-2019-20149), a new version of kind-of has been released.

Since global-prefix uses 6.0.2, this raises security flags.
